### PR TITLE
fix(output): add ANSI Erase Line escape to progress bar for Termux compatibility

### DIFF
--- a/internal/output/console.go
+++ b/internal/output/console.go
@@ -142,7 +142,7 @@ func (c *Console) ProgressBar(current, total int, label string) {
 
 	// Assemble the line.
 	var b strings.Builder
-	b.WriteString("\r  ")
+	b.WriteString("\r\033[2K  ")
 	b.WriteString(c.color(colorCyan, label))
 	b.WriteString("  ")
 	b.WriteString(c.color(colorGray, counterStr))


### PR DESCRIPTION
## Problem

On Termux, the progress bar prints a new line for each update instead of overwriting in place. This is because `ProgressBar` uses only `\r` (carriage return) which doesn't trigger a proper line redraw on Termux's PTY layer.

## Fix

Added `\033[2K` (ANSI Erase In Line) before the progress bar content, matching the approach already used by `ClearCurrentLine()` in the same file and by ghorgsync's progress bar implementation.

## Before

```
\r  <content>       — carriage return only
```

## After

```
\r\033[2K  <content>   — carriage return + erase line
```

This ensures the terminal clears the line buffer before writing fresh content, which is required on Termux (and is a more robust pattern in general).